### PR TITLE
Add TypeScript CLI skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Photo Genie
 
-A Node.js CLI providing photo utilities. Each utility lives in its own folder inside `src/utils` and exposes an `index.ts` entry point with a brief README.
+A Node.js CLI providing photo utilities. Each utility lives in its own folder
+inside `src/utils` and exposes an `index.ts` that exports a `commander`
+`Command` as the default export. Utilities are automatically loaded by the CLI
+so new commands can be added simply by creating a folder with an `index.ts` and
+README.
 
 ## Development
 
@@ -9,6 +13,12 @@ Install dependencies and build the CLI:
 ```bash
 npm install
 npm run build
+```
+
+After building, run the compiled CLI:
+
+```bash
+npx photo-genie <command>
 ```
 
 During development you can run the CLI via ts-node:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# photo-genie
-A photo utils repo for my needs
+# Photo Genie
+
+A Node.js CLI providing photo utilities. Each utility lives in its own folder inside `src/utils` and exposes an `index.ts` entry point with a brief README.
+
+## Development
+
+Install dependencies and build the CLI:
+
+```bash
+npm install
+npm run build
+```
+
+During development you can run the CLI via ts-node:
+
+```bash
+npm run dev -- delete-arw <directory>
+```
+
+## Utilities
+
+### delete-arw
+
+Deletes `.ARW` files when a JPEG of the same name is not present. See the [utility README](src/utils/delete-arw/README.md) for details.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "photo-genie",
+  "version": "1.0.0",
+  "description": "A photo utils repo for my needs",
+  "main": "dist/index.js",
+  "bin": {
+    "photo-genie": "dist/index.js"
+  },
+  "scripts": {
+    "build": "vite build",
+    "dev": "ts-node src/cli.ts",
+    "clean": "rm -rf dist"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "commander": "^10.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
-import { deleteOrphanArw } from './utils/delete-arw/index';
+import commands from './utils';
 
 const program = new Command();
 
@@ -9,11 +9,9 @@ program
   .description('Photo utilities CLI')
   .version('1.0.0');
 
-program
-  .command('delete-arw <dir>')
-  .description('Delete ARW files without matching JPEGs')
-  .action(async (dir: string) => {
-    await deleteOrphanArw(dir);
-  });
+
+for (const cmd of commands) {
+  program.addCommand(cmd);
+}
 
 program.parseAsync(process.argv);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { deleteOrphanArw } from './utils/delete-arw/index';
+
+const program = new Command();
+
+program
+  .name('photo-genie')
+  .description('Photo utilities CLI')
+  .version('1.0.0');
+
+program
+  .command('delete-arw <dir>')
+  .description('Delete ARW files without matching JPEGs')
+  .action(async (dir: string) => {
+    await deleteOrphanArw(dir);
+  });
+
+program.parseAsync(process.argv);

--- a/src/utils/delete-arw/README.md
+++ b/src/utils/delete-arw/README.md
@@ -1,0 +1,9 @@
+# Delete orphan ARW files
+
+Removes `.ARW` files that don't have a matching JPEG file in the same directory.
+
+## Usage
+
+```bash
+photo-genie delete-arw <directory>
+```

--- a/src/utils/delete-arw/index.ts
+++ b/src/utils/delete-arw/index.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import { extname, join } from 'path';
+import { Command } from 'commander';
 
 /**
  * Delete `.ARW` files that don't have matching JPEGs.
@@ -24,3 +25,15 @@ export async function deleteOrphanArw(dir: string): Promise<void> {
       })
   );
 }
+
+/**
+ * Commander command registration
+ */
+const command = new Command('delete-arw')
+  .argument('<dir>', 'directory to process')
+  .description('Delete ARW files without matching JPEGs')
+  .action(async (dir: string) => {
+    await deleteOrphanArw(dir);
+  });
+
+export default command;

--- a/src/utils/delete-arw/index.ts
+++ b/src/utils/delete-arw/index.ts
@@ -1,0 +1,26 @@
+import { promises as fs } from 'fs';
+import { extname, join } from 'path';
+
+/**
+ * Delete `.ARW` files that don't have matching JPEGs.
+ * @param dir Directory to process
+ */
+export async function deleteOrphanArw(dir: string): Promise<void> {
+  const files = await fs.readdir(dir);
+  const jpegs = new Set(
+    files
+      .filter((f) => extname(f).toLowerCase() === '.jpeg' || extname(f).toLowerCase() === '.jpg')
+      .map((f) => f.replace(/\.(jpeg|jpg)$/i, ''))
+  );
+
+  await Promise.all(
+    files
+      .filter((f) => extname(f).toLowerCase() === '.arw')
+      .map(async (f) => {
+        const base = f.replace(/\.arw$/i, '');
+        if (!jpegs.has(base)) {
+          await fs.unlink(join(dir, f));
+        }
+      })
+  );
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,3 @@
+import deleteArw from './delete-arw';
+
+export default [deleteArw];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/cli.ts'),
+      formats: ['cjs'],
+      fileName: () => 'index.js',
+    },
+    rollupOptions: {
+      external: ['fs', 'path', 'commander'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- initialize Node.js project with TypeScript and Vite config
- add CLI entrypoint using `commander`
- implement first util `delete-arw`
- document usage

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619f07c5f88333b9c508a52db4f487